### PR TITLE
Fix can't encode character '\u2606'

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,13 +37,13 @@ if(__name__ == '__main__'):
             dummy = data
             json_full += data['comments']
 
-            with open(f'{output}/{i * 50}-{(i + 1) * 50}.json', 'w') as file:
+            with open(f'{output}/{i * 50}-{(i + 1) * 50}.json', 'w', encoding='utf-8') as file:
                 file.write(dumps(data, ensure_ascii=False, indent=2))
                 logging.info(f'Output data : {output}/{i * 50}-{(i + 1) * 50}.json')
         
     dummy['comments'] = json_full
 
-    with open(f'{output}/full.json', 'w') as file:
+    with open(f'{output}/full.json', 'w', encoding='utf-8') as file:
         file.write(dumps(dummy, ensure_ascii=False, indent=2))
         logging.info(f'Output data : {output}/full.json')
     


### PR DESCRIPTION
Fixing encode character error by adding encoding='utf-8'.

![image](https://github.com/RomySaputraSihananda/tiktok-comment-scrapper/assets/61398214/1fd06723-3cdb-4dc2-8575-85adcb371921)

To reproduce the error use this vids : 7324611211142663429 (last checked 26 june)